### PR TITLE
fix an invalid const reference

### DIFF
--- a/QuickHull.cpp
+++ b/QuickHull.cpp
@@ -141,7 +141,7 @@ namespace quickhull {
 			visibleFaces.clear();
 			possiblyVisibleFaces.emplace_back(topFaceIndex,std::numeric_limits<size_t>::max());
 			while (possiblyVisibleFaces.size()) {
-				const auto& faceData = possiblyVisibleFaces.back();
+				const auto faceData = possiblyVisibleFaces.back();
 				possiblyVisibleFaces.pop_back();
 				auto& pvf = m_mesh.m_faces[faceData.m_faceIndex];
 				assert(!pvf.isDisabled());


### PR DESCRIPTION
This fixes a segfault where the faceData object gets destroyed after a std::vector::pop_back()

The unit tests still pass.