### PR TITLE
Clang warning - redundant move

### DIFF
--- a/QuickHull.hpp
+++ b/QuickHull.hpp
@@ -184,7 +184,7 @@ namespace quickhull {
 	
 	template<typename T>
 	std::unique_ptr<std::vector<size_t>> QuickHull<T>::getIndexVectorFromPool() {
-		auto r = std::move(m_indexVectorPool.get());
+		auto r = m_indexVectorPool.get();
 		r->clear();
 		return r;
 	}


### PR DESCRIPTION
Fixed warning about redundant `std::move()`, reported by Clang 12 with flag `-Wall`.
```
../../QuickHull.hpp:187:12: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
                auto r = std::move(m_indexVectorPool.get());
                         ^
../../QuickHull.hpp:187:12: note: remove std::move call here
                auto r = std::move(m_indexVectorPool.get());
                         ^~~~~~~~~~                       ~
```