### PR TITLE
Fix GCC 13 errors and warnings

### DIFF
--- a/QuickHull.cpp
+++ b/QuickHull.cpp
@@ -218,7 +218,7 @@ namespace quickhull {
 				}
 				// Disable the face, but retain pointer to the points that were on the positive side of it. We need to assign those points
 				// to the new faces we create shortly.
-				auto t = std::move(m_mesh.disableFace(faceIndex));
+				auto t = m_mesh.disableFace(faceIndex);
 				if (t) {
 					assert(t->size()); // Because we should not assign point vectors to faces unless needed...
 					m_disabledFacePointVectors.push_back(std::move(t));

--- a/QuickHull.hpp
+++ b/QuickHull.hpp
@@ -184,7 +184,7 @@ namespace quickhull {
 	
 	template<typename T>
 	std::unique_ptr<std::vector<size_t>> QuickHull<T>::getIndexVectorFromPool() {
-		auto r = std::move(m_indexVectorPool.get());
+		auto r = m_indexVectorPool.get();
 		r->clear();
 		return r;
 	}

--- a/Structs/Mesh.hpp
+++ b/Structs/Mesh.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include "VertexDataSource.hpp"
 #include <unordered_map>
+#include <cinttypes>
 
 namespace quickhull {
 
@@ -34,7 +35,7 @@ namespace quickhull {
 
 		struct Face {
 			size_t m_he;
-			Plane<T> m_P;
+			Plane<T> m_P{};
 			T m_mostDistantPointDist;
 			size_t m_mostDistantPoint;
 			size_t m_visibilityCheckedOnIteration;


### PR DESCRIPTION
This PR fixes a couple of errors and warnings when compiled on GCC 13 with `-Wall -Wextra -Wpedantic`.

This includes:
- missing `<cinttypes>` include
- unnecessary moves preventing copy elision
- maybe uninitialized `quickhull::MeshBuilder::Face::Plane<T> m_P` member warning